### PR TITLE
replace sed -i on /etc/hosts by simple sed with cp

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -104,4 +104,4 @@ fi
 
 # Remove temporary entry in /etc/hosts
 sudo sed '/yunopiwigo/d' /etc/hosts > /tmp/hosts.tmp
-sudo cp /tmp/hosts.tmp /etc/hosts ; rm -f /tmp/hosts.tmp
+sudo cp /tmp/hosts.tmp /etc/hosts ; sudo rm -f /tmp/hosts.tmp

--- a/scripts/install
+++ b/scripts/install
@@ -103,6 +103,5 @@ then
 fi
 
 # Remove temporary entry in /etc/hosts
-sudo sed -i '/yunopiwigo/d' /etc/hosts
-
-
+sudo sed '/yunopiwigo/d' /etc/hosts > /tmp/hosts.tmp
+sudo cp /tmp/hosts.tmp /etc/hosts ; rm -f /tmp/hosts.tmp


### PR DESCRIPTION
Hello, there is a problem on Docker to use "sed -i" on /etc/hosts file, because it's mouted on other fs.
However, it's possible to use simple sed with tempory file and cp / rm.
Thanks

Ref from Docker documentation : https://docs.docker.com/v1.3/userguide/dockervolumes/
Note: Many tools used to edit files including vi and sed --in-place may result in an inode change. Since Docker v1.1.0, this will produce an error such as "sed: cannot rename ./sedKdJ9Dy: Device or resource busy". In the case where you want to edit the mounted file, it is often easiest to instead mount the parent directory.